### PR TITLE
fix: install npm dependencies in weekly tag scan workflow (issue #62)

### DIFF
--- a/.github/workflows/weekly-tag-scan.yml
+++ b/.github/workflows/weekly-tag-scan.yml
@@ -32,6 +32,9 @@ jobs:
               with:
                   node-version: '24'
 
+            - name: Install dependencies
+              run: npm install
+
             - name: Run tag export
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly-tag-scan.yml
+++ b/.github/workflows/weekly-tag-scan.yml
@@ -31,9 +31,10 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: '24'
+                  cache: 'npm'
 
             - name: Install dependencies
-              run: npm install
+              run: npm ci
 
             - name: Run tag export
               env:


### PR DESCRIPTION
### Summary

The weekly tag scan workflow was failing because `js-yaml` (required by `scripts/export-tags.js`) was never installed on the runner. Added an `npm ci` step before the script runs.

---
**Closes #62**