### PR TITLE
fix: use PR_TOKEN for tag-scan workflow

### DIFF
--- a/.github/workflows/weekly-tag-scan.yml
+++ b/.github/workflows/weekly-tag-scan.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
               with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.PR_TOKEN }}
 
             - name: Set up Node
               uses: actions/setup-node@v6
@@ -43,7 +43,7 @@ jobs:
 
             - name: Compute new tags and manage PR
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.PR_TOKEN }}
               run: |
                   # Collect lines added vs main (new tags).
                   # grep '^+[^+]' captures added lines but not the '+++' diff header.

--- a/.github/workflows/weekly-tag-scan.yml
+++ b/.github/workflows/weekly-tag-scan.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
               with:
-                  token: ${{ secrets.PR_TOKEN }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Set up Node
               uses: actions/setup-node@v6

--- a/.github/workflows/weekly-tag-scan.yml
+++ b/.github/workflows/weekly-tag-scan.yml
@@ -93,7 +93,9 @@ jobs:
                   # any contributor commits. Otherwise create it fresh from main.
                   if git ls-remote --exit-code origin tag-scan/auto > /dev/null 2>&1; then
                       git fetch origin tag-scan/auto
+                      git stash
                       git checkout tag-scan/auto
+                      git stash pop
                   else
                       git checkout -b tag-scan/auto
                   fi

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Tags from GitHub topics and Hugging Face card metadata are free-form text, so th
 
 When first setting up your catalog, run the export script to generate a full list of your organization's current raw tags (saved to `scripts/tag-export.txt`), then use that list to build your initial `tag-groups.js`. A weekly GitHub Actions workflow will automatically open a pull request whenever 5 or more new tags (relative to the last committed baseline in `scripts/tag-export.txt`) are detected, keeping your tag groups up to date over time.
 
-> **Required secret:** The weekly tag scan workflow requires a fine-grained PAT stored as a repository secret named `PR_TOKEN` (Settings → Secrets and variables → Actions). The PAT must have **Contents: Read and write** and **Pull requests: Read and write** permissions on the catalog repo.
+> **Required secret:** The weekly tag scan workflow requires a fine-grained PAT stored as a repository secret named `PR_TOKEN` (Settings → Secrets and variables → Actions). The PAT must have **Pull requests: Read and write** permission on the catalog repo. 
 
 See **[docs/tag-grouping-process.md](docs/tag-grouping-process.md)** for full setup instructions, conventions, and guidance on using AI assistance for the initial grouping pass.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Tags from GitHub topics and Hugging Face card metadata are free-form text, so th
 
 When first setting up your catalog, run the export script to generate a full list of your organization's current raw tags (saved to `scripts/tag-export.txt`), then use that list to build your initial `tag-groups.js`. A weekly GitHub Actions workflow will automatically open a pull request whenever 5 or more new tags (relative to the last committed baseline in `scripts/tag-export.txt`) are detected, keeping your tag groups up to date over time.
 
+> **Required secret:** The weekly tag scan workflow requires a fine-grained PAT stored as a repository secret named `PR_TOKEN` (Settings → Secrets and variables → Actions). The PAT must have **Contents: Read and write** and **Pull requests: Read and write** permissions on the catalog repo.
+
 See **[docs/tag-grouping-process.md](docs/tag-grouping-process.md)** for full setup instructions, conventions, and guidance on using AI assistance for the initial grouping pass.
 
 ## Local Testing

--- a/docs/tag-grouping-process.md
+++ b/docs/tag-grouping-process.md
@@ -71,6 +71,10 @@ the GitHub and Hugging Face APIs, diffs them against the committed baseline in
 `scripts/tag-export.txt`, and opens (or updates) a pull request titled
 **`[Tag Scan] New tags detected — review tag-groups.js`** whenever 5 or more new tags appear.
 
+> **Prerequisite:** The workflow requires a fine-grained PAT stored as a repository secret named
+> `PR_TOKEN` with **Contents: Read and write** and **Pull requests: Read and write** permissions.
+> Without it, the workflow will find new tags but fail when attempting to open the PR.
+
 You should update `public/tag-groups.js` when that PR is opened or updated.
 
 ---

--- a/docs/tag-grouping-process.md
+++ b/docs/tag-grouping-process.md
@@ -72,8 +72,8 @@ the GitHub and Hugging Face APIs, diffs them against the committed baseline in
 **`[Tag Scan] New tags detected — review tag-groups.js`** whenever 5 or more new tags appear.
 
 > **Prerequisite:** The workflow requires a fine-grained PAT stored as a repository secret named
-> `PR_TOKEN` with **Contents: Read and write** and **Pull requests: Read and write** permissions.
-> Without it, the workflow will find new tags but fail when attempting to open the PR.
+> `PR_TOKEN` with **Pull requests: Read and write** permission. Without it, the workflow will find
+> new tags and push the branch successfully, but fail when attempting to open the PR.
 
 You should update `public/tag-groups.js` when that PR is opened or updated.
 


### PR DESCRIPTION
### Summary

The weekly tag scan workflow was failing to open PRs due to org-level restrictions on `GITHUB_TOKEN` that prevent it from creating pull requests. Replaced `GITHUB_TOKEN` with a fine-grained PAT (`PR_TOKEN`) for the checkout and `gh` CLI steps, which covers both the `git push` and `gh pr create` calls.

### Testing

Verified working by running [workflow on this branch](https://github.com/Imageomics/catalog/actions/runs/23757227827)