### PR TITLE
New version (4.1.0) release updates to metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -31,9 +31,9 @@
       "searchability"
     ],
     "title": "Imageomics Catalog",
-    "version": "4.0.1",
+    "version": "4.1.0",
     "license": "MIT",
-    "publication_date": "2026-03-23",
+    "publication_date": "2026-04-22",
     "grants": [
         {
             "id": "021nxhr62::2118240"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,14 +11,14 @@ authors:
   given-names: "Balaji"
   affiliation: "The Ohio State University"
 cff-version: 1.2.0
-date-released: "2026-03-23"
+date-released: "2026-04-22"
 identifiers:
-  - description: "The GitHub release URL of tag v4.0.1."
+  - description: "The GitHub release URL of tag v4.1.0."
     type: url
-    value: "https://github.com/Imageomics/catalog/releases/tag/v4.0.1"
-  - description: "The GitHub URL of the commit tagged with v4.0.1."
+    value: "https://github.com/Imageomics/catalog/releases/tag/v4.1.0"
+  - description: "The GitHub URL of the commit tagged with v4.1.0."
     type: url
-    value: "https://github.com/Imageomics/catalog/tree/8842389e2a80ff608623912142ccc01342e04b21"
+    value: "https://github.com/Imageomics/catalog/tree/<commit-hash>"
 keywords:
   - imageomics
   - code
@@ -37,6 +37,6 @@ license: MIT
 message: "If you use this software, please cite it as below."
 repository-code: "https://github.com/Imageomics/catalog"
 title: "Imageomics Catalog"
-version: "4.0.1"
+version: "4.1.0"
 doi: "10.5281/zenodo.17602801"
 type: software

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "catalog",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "catalog",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catalog",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Repository for web-based Imageomics code, data, model, and spaces catalog. This catalog is designed to use the GitHub API for searching all code repositories created under the [Imageomics GitHub Organization](https://github.com/Imageomics) and the Hugging Face API for searching all dataset, model, and spaces repositories created under the [Imageomics Hugging Face Organization](https://huggingface.co/imageomics).",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Minor version release. Updated:

- [x] Citation file
- [x] Zenodo metadata
- [x] `package.json` then ran `npm install` to update `package-lock.json`