### PR TITLE
fix: alphabetical sort places additional repos last/first

### DIFF
--- a/main.js
+++ b/main.js
@@ -622,11 +622,11 @@ const applyFiltersAndSort = async (updateUrl = true) => {
     let sorted = [...filtered];
     switch (sortBy) {
         case 'alphabetical_asc':
-            sorted.sort((a, b) => a.id.split('/').pop().localeCompare(b.id.split('/').pop()));
+            sorted.sort((a, b) => a.id.split('/').pop().localeCompare(b.id.split('/').pop()) || a.id.localeCompare(b.id));
             break;
 
         case 'alphabetical_desc':
-            sorted.sort((a, b) => b.id.split('/').pop().localeCompare(a.id.split('/').pop()));
+            sorted.sort((a, b) => b.id.split('/').pop().localeCompare(a.id.split('/').pop()) || b.id.localeCompare(a.id));
             break;
 
         case 'stars_desc':

--- a/main.js
+++ b/main.js
@@ -622,11 +622,11 @@ const applyFiltersAndSort = async (updateUrl = true) => {
     let sorted = [...filtered];
     switch (sortBy) {
         case 'alphabetical_asc':
-            sorted.sort((a, b) => a.id.localeCompare(b.id));
+            sorted.sort((a, b) => a.id.split('/').pop().localeCompare(b.id.split('/').pop()));
             break;
 
         case 'alphabetical_desc':
-            sorted.sort((a, b) => b.id.localeCompare(a.id));
+            sorted.sort((a, b) => b.id.split('/').pop().localeCompare(a.id.split('/').pop()));
             break;
 
         case 'stars_desc':

--- a/main.js
+++ b/main.js
@@ -622,11 +622,19 @@ const applyFiltersAndSort = async (updateUrl = true) => {
     let sorted = [...filtered];
     switch (sortBy) {
         case 'alphabetical_asc':
-            sorted.sort((a, b) => a.id.split('/').pop().localeCompare(b.id.split('/').pop()) || a.id.localeCompare(b.id));
+            sorted.sort((a, b) => {
+                const aName = a.cardData?.pretty_name || a.cardData?.model_name || a.cardData?.title || a.id.split('/').pop();
+                const bName = b.cardData?.pretty_name || b.cardData?.model_name || b.cardData?.title || b.id.split('/').pop();
+                return aName.localeCompare(bName) || a.id.localeCompare(b.id);
+            });
             break;
 
         case 'alphabetical_desc':
-            sorted.sort((a, b) => b.id.split('/').pop().localeCompare(a.id.split('/').pop()) || b.id.localeCompare(a.id));
+            sorted.sort((a, b) => {
+                const aName = a.cardData?.pretty_name || a.cardData?.model_name || a.cardData?.title || a.id.split('/').pop();
+                const bName = b.cardData?.pretty_name || b.cardData?.model_name || b.cardData?.title || b.id.split('/').pop();
+                return bName.localeCompare(aName) || b.id.localeCompare(a.id);
+            });
             break;
 
         case 'stars_desc':


### PR DESCRIPTION
## Problem
Repos added via `ADDITIONAL_REPOS` or `ADDITIONAL_HF_REPOS` from external orgs/users were always sorted to the end (or beginning for reverse) during alphabetical sorting. The sort compared the full `owner/repo-name` id, so repos were grouped by owner prefix rather than interleaved by repo name.

## Solution
Extract only the repo name (the part after `/`) from the id before comparing, so all repos sort together by name regardless of which org they belong to.

<img width="1801" height="997" alt="image" src="https://github.com/user-attachments/assets/a32ff1fc-23fd-4c02-b992-9a0619429f16" />


Closes #81