### PR TITLE
fix: use absolute URL for tag-grouping-process.md link in tag scan PR

### DIFF
--- a/.github/workflows/weekly-tag-scan.yml
+++ b/.github/workflows/weekly-tag-scan.yml
@@ -44,6 +44,7 @@ jobs:
             - name: Compute new tags and manage PR
               env:
                   GH_TOKEN: ${{ secrets.PR_TOKEN }}
+                  REPO_URL: ${{ github.server_url }}/${{ github.repository }}
               run: |
                   # Collect lines added vs main (new tags).
                   # grep '^+[^+]' captures added lines but not the '+++' diff header.
@@ -75,7 +76,7 @@ jobs:
                       echo ""
                       echo "## How to Resolve"
                       echo ""
-                      echo "See [docs/tag-grouping-process.md](https://github.com/Imageomics/catalog/blob/main/docs/tag-grouping-process.md) for full instructions."
+                      echo "See [docs/tag-grouping-process.md](${REPO_URL}/blob/main/docs/tag-grouping-process.md) for full instructions."
                       echo ""
                       echo "In short:"
                       echo "1. For each tag above, open \`public/tag-groups.js\`."

--- a/.github/workflows/weekly-tag-scan.yml
+++ b/.github/workflows/weekly-tag-scan.yml
@@ -75,7 +75,7 @@ jobs:
                       echo ""
                       echo "## How to Resolve"
                       echo ""
-                      echo "See [docs/tag-grouping-process.md](docs/tag-grouping-process.md) for full instructions."
+                      echo "See [docs/tag-grouping-process.md](https://github.com/Imageomics/catalog/blob/main/docs/tag-grouping-process.md) for full instructions."
                       echo ""
                       echo "In short:"
                       echo "1. For each tag above, open \`public/tag-groups.js\`."


### PR DESCRIPTION
Fixes #84.

The auto-generated tag scan PR body used a relative link to `docs/tag-grouping-process.md`, which GitHub resolves relative to the PR diff URL rather than the repo root. Replaced with an absolute URL built from `${{ github.server_url }}` and `${{ github.repository }}` so it works correctly regardless of repo name, org, or GitHub instance.