### PR TITLE
feat: add test suite and extract shared config validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Run tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - 'public/config.yaml'
+      - 'src/**'
+      - 'tests/**'
+      - 'package*.json'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - 'public/config.yaml'
-      - 'src/**'
-      - 'tests/**'
-      - 'package*.json'
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -101,13 +101,7 @@ When first setting up your catalog, run the export script to generate a full lis
 
 See **[docs/tag-grouping-process.md](docs/tag-grouping-process.md)** for full setup instructions, conventions, and guidance on using AI assistance for the initial grouping pass.
 
-## Tests
-
-Tests are written with [Vitest](https://vitest.dev/) and run automatically in CI on every pull request to `main`. To run them locally: `npm test` (single run) or `npm run test:watch` (watch mode).
-
-`tests/validateConfig.test.js` tests the validator logic in `src/validateConfig.js`, which is also used by the `fetch-releases` and `export-tags` scripts. `tests/config.integration.test.js` confirms that the real `public/config.yaml` passes that same validation.
-
-### Local Testing
+## Prerequisites
 
 This project uses [Vite](https://vite.dev/) as a build tool and requires **Node.js 24** (Active LTS). You can check your current version with `node --version`. To install or update Node, visit [nodejs.org](https://nodejs.org/en/download) or use a version manager like [nvm](https://github.com/nvm-sh/nvm):
 
@@ -117,6 +111,14 @@ nvm use
 ```
 
 A `.nvmrc` file is included, so `nvm use` will automatically select the correct version in the project directory.
+
+## Testing
+
+Tests are written with [Vitest](https://vitest.dev/) and run automatically in CI on every pull request to `main`. To run them locally: `npm test` (single run) or `npm run test:watch` (watch mode).
+
+`tests/validateConfig.test.js` tests the validator logic in `src/validateConfig.js`, which is also used by the `fetch-releases` and `export-tags` scripts. `tests/config.integration.test.js` confirms that the real `public/config.yaml` passes that same validation.
+
+### Running Locally
 
 Install dependencies and start the dev server from the repo root:
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,13 @@ When first setting up your catalog, run the export script to generate a full lis
 
 See **[docs/tag-grouping-process.md](docs/tag-grouping-process.md)** for full setup instructions, conventions, and guidance on using AI assistance for the initial grouping pass.
 
-## Local Testing
+## Tests
+
+Tests are written with [Vitest](https://vitest.dev/) and run automatically in CI on every pull request to `main`. To run them locally: `npm test` (single run) or `npm run test:watch` (watch mode).
+
+`tests/validateConfig.test.js` tests the validator logic in `src/validateConfig.js`, which is also used by the `fetch-releases` and `export-tags` scripts. `tests/config.integration.test.js` confirms that the real `public/config.yaml` passes that same validation.
+
+### Local Testing
 
 This project uses [Vite](https://vite.dev/) as a build tool and requires **Node.js 24** (Active LTS). You can check your current version with `node --version`. To install or update Node, visit [nodejs.org](https://nodejs.org/en/download) or use a version manager like [nvm](https://github.com/nvm-sh/nvm):
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Welcome to your new catalog repo! The primary way to personalize this catalog is
 
 * **Organization & Repository Settings:**
   * `ORGANIZATION_NAME`: Your GitHub/Hugging Face organization name (lowercase for API calls)
-  * `GITHUB_ORG_NAME`: Display name for your organization (can differ from API name)
+  * `ORG_NAME`: Display name for your organization (can differ from API name); used as fallback site title if `CATALOG_TITLE` is not set
   * `CATALOG_REPO_NAME`: Repository name for the catalog itself (used for stats badge)
 
 * **Branding:**

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@
 //
 
 import jsYaml from 'js-yaml';
+import { validateConfig } from './src/validateConfig.js';
 
 // Start fetching config immediately when the module loads (before DOMContentLoaded)
 // so the fetch is in-flight while the DOM is being parsed.
@@ -757,28 +758,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         CONFIG = await configPromise;
 
         // Validate required fields so devs get a clear error instead of a cryptic crash
-        const missing = [];
-        if (!CONFIG.ORGANIZATION_NAME)                 missing.push('ORGANIZATION_NAME');
-        if (!CONFIG.API_BASE_URL)                      missing.push('API_BASE_URL');
-        if (CONFIG.REFRESH_INTERVAL_DAYS == null)      missing.push('REFRESH_INTERVAL_DAYS');
-        if (!Array.isArray(CONFIG.ADDITIONAL_REPOS))    missing.push('ADDITIONAL_REPOS (must be a list)');
-        if (!Array.isArray(CONFIG.ADDITIONAL_HF_REPOS)) {
-            missing.push('ADDITIONAL_HF_REPOS (must be a list)');
-        } else {
-            const validTypes = new Set(['datasets', 'models', 'spaces']);
-            const badEntries = CONFIG.ADDITIONAL_HF_REPOS.filter(
-                e => !e || typeof e.repo !== 'string' || !e.repo.trim() || !validTypes.has(e.type)
-            );
-            if (badEntries.length) missing.push(
-                `ADDITIONAL_HF_REPOS entries must each have a non-empty "repo" string and "type" in {datasets, models, spaces}; bad entries: ${badEntries.map(e => JSON.stringify(e)).join(', ')}`
-            );
-        }
-        if (!CONFIG.COLORS || typeof CONFIG.COLORS !== 'object') {
-            missing.push('COLORS (must be an object with primary, secondary, accent, accentDark, tag)');
-        } else {
-            const missingColors = ['primary', 'secondary', 'accent', 'accentDark', 'tag'].filter(k => !CONFIG.COLORS[k]);
-            if (missingColors.length) missing.push(`COLORS keys: ${missingColors.join(', ')}`);
-        }
+        const missing = validateConfig(CONFIG);
         if (missing.length) throw new Error(`config.yaml is missing required fields: ${missing.join('; ')}`);
     } catch (error) {
         console.error('Error loading config.yaml:', error);

--- a/main.js
+++ b/main.js
@@ -759,7 +759,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         // Validate required fields so devs get a clear error instead of a cryptic crash
         const missing = validateConfig(CONFIG);
-        if (missing.length) throw new Error(`config.yaml is missing required fields: ${missing.join('; ')}`);
+        if (missing.length) throw new Error(`Invalid config.yaml: ${missing.join('; ')}`);
     } catch (error) {
         console.error('Error loading config.yaml:', error);
         // Render visible error banner

--- a/main.js
+++ b/main.js
@@ -7,7 +7,6 @@
 //
 
 import jsYaml from 'js-yaml';
-import { validateConfig } from './src/validateConfig.js';
 
 // Start fetching config immediately when the module loads (before DOMContentLoaded)
 // so the fetch is in-flight while the DOM is being parsed.
@@ -756,10 +755,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Load config before anything else
     try {
         CONFIG = await configPromise;
-
-        // Validate required fields so devs get a clear error instead of a cryptic crash
-        const missing = validateConfig(CONFIG);
-        if (missing.length) throw new Error(`Invalid config.yaml: ${missing.join('; ')}`);
     } catch (error) {
         console.error('Error loading config.yaml:', error);
         // Render visible error banner

--- a/main.js
+++ b/main.js
@@ -783,7 +783,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     ADDITIONAL_HF_REPOS   = CONFIG.ADDITIONAL_HF_REPOS;
 
     // Apply CSS custom properties and document metadata
-    document.title = CONFIG.CATALOG_TITLE || CONFIG.ORG_NAME || 'Catalog';
+    document.title = CONFIG.CATALOG_TITLE || `${CONFIG.ORG_NAME} Catalog`;
     document.documentElement.style.setProperty('--color-primary',     CONFIG.COLORS?.primary     || '#92991c');
     document.documentElement.style.setProperty('--color-secondary',   CONFIG.COLORS?.secondary   || '#5d8095');
     document.documentElement.style.setProperty('--color-accent',      CONFIG.COLORS?.accent      || '#0097b2');

--- a/main.js
+++ b/main.js
@@ -708,7 +708,7 @@ const initializeUIFromConfig = () => {
     const logoImg = document.getElementById('logo-img');
     if (logoImg) {
         logoImg.src = CONFIG.LOGO_URL;
-        logoImg.alt = CONFIG.GITHUB_ORG_NAME + ' Logo';
+        logoImg.alt = CONFIG.ORG_NAME + ' Logo';
 
         logoImg.onload = () => {
             logoImg.classList.remove('opacity-0');
@@ -765,7 +765,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         setTimeout(() => errorDiv.remove(), 10000);
         // Fall back to defaults so the page isn't completely broken
         CONFIG = {
-            ORGANIZATION_NAME: '', CATALOG_REPO_NAME: '', GITHUB_ORG_NAME: '',
+            ORGANIZATION_NAME: '', CATALOG_REPO_NAME: '', ORG_NAME: '',
             CATALOG_TITLE: 'Catalog', CATALOG_DESCRIPTION: '',
             LOGO_URL: '', FAVICON_URL: '',
             COLORS: { primary: '#92991c', secondary: '#5d8095', accent: '#0097b2', accentDark: '#4fd1eb', tag: '#9bcb5e' },
@@ -783,7 +783,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     ADDITIONAL_HF_REPOS   = CONFIG.ADDITIONAL_HF_REPOS;
 
     // Apply CSS custom properties and document metadata
-    document.title = CONFIG.CATALOG_TITLE || 'Catalog';
+    document.title = CONFIG.CATALOG_TITLE || CONFIG.ORG_NAME || 'Catalog';
     document.documentElement.style.setProperty('--color-primary',     CONFIG.COLORS?.primary     || '#92991c');
     document.documentElement.style.setProperty('--color-secondary',   CONFIG.COLORS?.secondary   || '#5d8095');
     document.documentElement.style.setProperty('--color-accent',      CONFIG.COLORS?.accent      || '#0097b2');

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "tailwindcss": "^4.2.1",
-        "vite": "^7.3.2"
+        "vite": "^7.3.2",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=24"
@@ -862,6 +863,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
@@ -1198,6 +1206,24 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1205,11 +1231,151 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1234,6 +1400,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1275,6 +1448,26 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1629,6 +1822,24 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1723,6 +1934,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1732,6 +1950,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
@@ -1754,6 +1986,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -1769,6 +2018,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vite": {
@@ -1844,6 +2103,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,27 +6,29 @@
   "scripts": {
     "dev": "vite",
     "build": "node scripts/fetch-releases.js && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Imageomics/catalog.git"
   },
   "keywords": [
-      "imageomics",
-      "code",
-      "data",
-      "models",
-      "spaces",
-      "GitHub",
-      "Hugging Face",
-      "APIs",
-      "inventory",
-      "catalog",
-      "keyword search",
-      "discoverability",
-      "searchability"
-    ],
+    "imageomics",
+    "code",
+    "data",
+    "models",
+    "spaces",
+    "GitHub",
+    "Hugging Face",
+    "APIs",
+    "inventory",
+    "catalog",
+    "keyword search",
+    "discoverability",
+    "searchability"
+  ],
   "author": "Elizabeth Campolongo",
   "license": "MIT",
   "engines": {
@@ -43,6 +45,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.1",
     "tailwindcss": "^4.2.1",
-    "vite": "^7.3.2"
+    "vite": "^7.3.2",
+    "vitest": "^4.1.5"
   }
 }

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -3,7 +3,7 @@
 
 # Organization & Repository Settings
 ORGANIZATION_NAME: imageomics       # GitHub/Hugging Face organization name (lowercase for API calls)
-GITHUB_ORG_NAME: Imageomics         # Display name for GitHub organization (can differ from API name)
+ORG_NAME: Imageomics                 # Display name for GitHub organization (can differ from API name)
 CATALOG_REPO_NAME: catalog          # Repository name for the catalog itself (used for stats badge)
 
 # Branding

--- a/scripts/export-tags.js
+++ b/scripts/export-tags.js
@@ -16,6 +16,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import jsYaml from 'js-yaml';
+import { validateConfig } from '../src/validateConfig.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -25,40 +26,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const configPath = path.resolve(__dirname, '../public/config.yaml');
 const rawConfig = jsYaml.load(fs.readFileSync(configPath, 'utf8'));
 
-if (!rawConfig || typeof rawConfig !== 'object' || Array.isArray(rawConfig)) {
-    throw new Error(`Invalid config at ${configPath}: expected a YAML mapping/object.`);
-}
-
-const requiredKeys = ['ORGANIZATION_NAME', 'API_BASE_URL', 'ADDITIONAL_REPOS'];
-const missingKeys = requiredKeys.filter((key) => !(key in rawConfig));
-if (missingKeys.length > 0) {
-    throw new Error(
-        `Invalid config at ${configPath}: missing required key(s): ${missingKeys.join(', ')}`
-    );
-}
-
-if (!Array.isArray(rawConfig.ADDITIONAL_REPOS)) {
-    throw new Error(
-        `Invalid config at ${configPath}: ADDITIONAL_REPOS must be an array.`
-    );
+const errors = validateConfig(rawConfig);
+if (errors.length) {
+    throw new Error(`Invalid config at ${configPath}: ${errors.join('; ')}`);
 }
 
 const CONFIG = rawConfig;
 const { ORGANIZATION_NAME, API_BASE_URL, ADDITIONAL_REPOS } = CONFIG;
-if (!Array.isArray(CONFIG.ADDITIONAL_HF_REPOS)) {
-    throw new Error(
-        `Invalid config at ${configPath}: ADDITIONAL_HF_REPOS must be an array.`
-    );
-}
-const validHFTypes = new Set(['datasets', 'models', 'spaces']);
-const badHFEntries = CONFIG.ADDITIONAL_HF_REPOS.filter(
-    e => !e || typeof e.repo !== 'string' || !e.repo.trim() || !validHFTypes.has(e.type)
-);
-if (badHFEntries.length) {
-    throw new Error(
-        `Invalid config at ${configPath}: ADDITIONAL_HF_REPOS entries must each have a non-empty "repo" string and "type" in {datasets, models, spaces}; bad entries: ${badHFEntries.map(e => JSON.stringify(e)).join(', ')}`
-    );
-}
 const ADDITIONAL_HF_REPOS = CONFIG.ADDITIONAL_HF_REPOS;
 
 // ---------------------------------------------------------------------------

--- a/scripts/fetch-releases.js
+++ b/scripts/fetch-releases.js
@@ -5,6 +5,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import jsYaml from 'js-yaml';
+import { validateConfig } from '../src/validateConfig.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,15 +14,9 @@ const __dirname = dirname(__filename);
 const configPath = join(__dirname, '../public/config.yaml');
 const CONFIG = jsYaml.load(readFileSync(configPath, 'utf8'));
 
-if (!CONFIG || typeof CONFIG !== 'object' || Array.isArray(CONFIG)) {
-    throw new Error(`Invalid config at ${configPath}: expected a YAML mapping/object.`);
-}
-const missingKeys = ['ORGANIZATION_NAME', 'ADDITIONAL_REPOS'].filter(k => !(k in CONFIG));
-if (missingKeys.length > 0) {
-    throw new Error(`Invalid config at ${configPath}: missing required key(s): ${missingKeys.join(', ')}`);
-}
-if (!Array.isArray(CONFIG.ADDITIONAL_REPOS)) {
-    throw new Error(`Invalid config at ${configPath}: ADDITIONAL_REPOS must be an array.`);
+const errors = validateConfig(CONFIG);
+if (errors.length) {
+    throw new Error(`Invalid config at ${configPath}: ${errors.join('; ')}`);
 }
 
 const TOKEN = process.env.GITHUB_TOKEN;

--- a/src/validateConfig.js
+++ b/src/validateConfig.js
@@ -1,0 +1,46 @@
+const VALID_HF_TYPES = new Set(['datasets', 'models', 'spaces']);
+const REQUIRED_COLOR_KEYS = ['primary', 'secondary', 'accent', 'accentDark', 'tag'];
+
+/**
+ * Validates a parsed config object against all required fields and shapes.
+ * @param {unknown} config - The parsed config (from config.yaml)
+ * @returns {string[]} Array of error messages; empty means valid.
+ */
+export function validateConfig(config) {
+    const errors = [];
+
+    if (!config || typeof config !== 'object' || Array.isArray(config)) {
+        errors.push('config must be a YAML mapping/object');
+        return errors;
+    }
+
+    if (!config.ORGANIZATION_NAME)            errors.push('ORGANIZATION_NAME');
+    if (!config.API_BASE_URL)                 errors.push('API_BASE_URL');
+    if (config.REFRESH_INTERVAL_DAYS == null) errors.push('REFRESH_INTERVAL_DAYS');
+
+    if (!Array.isArray(config.ADDITIONAL_REPOS)) {
+        errors.push('ADDITIONAL_REPOS (must be a list)');
+    }
+
+    if (!Array.isArray(config.ADDITIONAL_HF_REPOS)) {
+        errors.push('ADDITIONAL_HF_REPOS (must be a list)');
+    } else {
+        const badEntries = config.ADDITIONAL_HF_REPOS.filter(
+            e => !e || typeof e.repo !== 'string' || !e.repo.trim() || !VALID_HF_TYPES.has(e.type)
+        );
+        if (badEntries.length) {
+            errors.push(
+                `ADDITIONAL_HF_REPOS entries must each have a non-empty "repo" string and "type" in {datasets, models, spaces}; bad entries: ${badEntries.map(e => JSON.stringify(e)).join(', ')}`
+            );
+        }
+    }
+
+    if (!config.COLORS || typeof config.COLORS !== 'object') {
+        errors.push('COLORS (must be an object with primary, secondary, accent, accentDark, tag)');
+    } else {
+        const missingColors = REQUIRED_COLOR_KEYS.filter(k => !config.COLORS[k]);
+        if (missingColors.length) errors.push(`COLORS keys: ${missingColors.join(', ')}`);
+    }
+
+    return errors;
+}

--- a/src/validateConfig.js
+++ b/src/validateConfig.js
@@ -15,6 +15,8 @@ export function validateConfig(config) {
     }
 
     if (!config.ORGANIZATION_NAME)            errors.push('ORGANIZATION_NAME');
+    if (!config.ORG_NAME)                     errors.push('ORG_NAME');
+    if (!config.CATALOG_REPO_NAME)            errors.push('CATALOG_REPO_NAME');
     if (!config.API_BASE_URL)                 errors.push('API_BASE_URL');
     if (config.REFRESH_INTERVAL_DAYS == null) errors.push('REFRESH_INTERVAL_DAYS');
 

--- a/tests/config.integration.test.js
+++ b/tests/config.integration.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import jsYaml from 'js-yaml';
+import { validateConfig } from '../src/validateConfig.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const configPath = resolve(__dirname, '../public/config.yaml');
+
+describe('public/config.yaml', () => {
+    it('parses as a valid YAML object', () => {
+        const raw = readFileSync(configPath, 'utf8');
+        const config = jsYaml.load(raw);
+        expect(config).toBeTruthy();
+        expect(typeof config).toBe('object');
+        expect(Array.isArray(config)).toBe(false);
+    });
+
+    it('passes all validation checks', () => {
+        const config = jsYaml.load(readFileSync(configPath, 'utf8'));
+        const errors = validateConfig(config);
+        expect(errors).toEqual([]);
+    });
+});

--- a/tests/validateConfig.test.js
+++ b/tests/validateConfig.test.js
@@ -27,9 +27,9 @@ describe('validateConfig', () => {
         const config = {
             ...VALID_CONFIG,
             ADDITIONAL_HF_REPOS: [
-                { repo: 'imageomics/demo', type: 'datasets' },
+                { repo: 'imageomics/data', type: 'datasets' },
                 { repo: 'imageomics/model', type: 'models' },
-                { repo: 'imageomics/space', type: 'spaces' },
+                { repo: 'imageomics/demo', type: 'spaces' },
             ],
         };
         expect(validateConfig(config)).toEqual([]);

--- a/tests/validateConfig.test.js
+++ b/tests/validateConfig.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { validateConfig } from '../src/validateConfig.js';
+
+const VALID_CONFIG = {
+    ORGANIZATION_NAME: 'imageomics',
+    GITHUB_ORG_NAME: 'Imageomics',
+    CATALOG_REPO_NAME: 'catalog',
+    API_BASE_URL: 'https://huggingface.co/api/',
+    REFRESH_INTERVAL_DAYS: 30,
+    ADDITIONAL_REPOS: [],
+    ADDITIONAL_HF_REPOS: [],
+    COLORS: {
+        primary: '#92991c',
+        secondary: '#5d8095',
+        accent: '#0097b2',
+        accentDark: '#4fd1eb',
+        tag: '#9bcb5e',
+    },
+};
+
+describe('validateConfig', () => {
+    it('returns no errors for a valid config', () => {
+        expect(validateConfig(VALID_CONFIG)).toEqual([]);
+    });
+
+    it('returns no errors when ADDITIONAL_HF_REPOS has valid entries', () => {
+        const config = {
+            ...VALID_CONFIG,
+            ADDITIONAL_HF_REPOS: [
+                { repo: 'imageomics/demo', type: 'datasets' },
+                { repo: 'imageomics/model', type: 'models' },
+                { repo: 'imageomics/space', type: 'spaces' },
+            ],
+        };
+        expect(validateConfig(config)).toEqual([]);
+    });
+
+    it('errors on null config', () => {
+        expect(validateConfig(null).length).toBeGreaterThan(0);
+    });
+
+    it('errors on array config', () => {
+        expect(validateConfig([]).length).toBeGreaterThan(0);
+    });
+
+    it('errors when ORGANIZATION_NAME is missing', () => {
+        const { ORGANIZATION_NAME: _, ...config } = VALID_CONFIG;
+        expect(validateConfig(config)).toContain('ORGANIZATION_NAME');
+    });
+
+    it('errors when ORGANIZATION_NAME is empty string', () => {
+        expect(validateConfig({ ...VALID_CONFIG, ORGANIZATION_NAME: '' })).toContain('ORGANIZATION_NAME');
+    });
+
+    it('errors when API_BASE_URL is missing', () => {
+        const { API_BASE_URL: _, ...config } = VALID_CONFIG;
+        expect(validateConfig(config)).toContain('API_BASE_URL');
+    });
+
+    it('errors when REFRESH_INTERVAL_DAYS is null', () => {
+        expect(validateConfig({ ...VALID_CONFIG, REFRESH_INTERVAL_DAYS: null })).toContain('REFRESH_INTERVAL_DAYS');
+    });
+
+    it('errors when ADDITIONAL_REPOS is not an array', () => {
+        const errors = validateConfig({ ...VALID_CONFIG, ADDITIONAL_REPOS: 'repo/name' });
+        expect(errors.some(e => e.includes('ADDITIONAL_REPOS'))).toBe(true);
+    });
+
+    it('errors when ADDITIONAL_HF_REPOS is not an array', () => {
+        const errors = validateConfig({ ...VALID_CONFIG, ADDITIONAL_HF_REPOS: null });
+        expect(errors.some(e => e.includes('ADDITIONAL_HF_REPOS'))).toBe(true);
+    });
+
+    it('errors when an ADDITIONAL_HF_REPOS entry is missing repo', () => {
+        const config = {
+            ...VALID_CONFIG,
+            ADDITIONAL_HF_REPOS: [{ type: 'datasets' }],
+        };
+        const errors = validateConfig(config);
+        expect(errors.some(e => e.includes('ADDITIONAL_HF_REPOS'))).toBe(true);
+    });
+
+    it('errors when an ADDITIONAL_HF_REPOS entry has an invalid type', () => {
+        const config = {
+            ...VALID_CONFIG,
+            ADDITIONAL_HF_REPOS: [{ repo: 'imageomics/demo', type: 'notebooks' }],
+        };
+        const errors = validateConfig(config);
+        expect(errors.some(e => e.includes('ADDITIONAL_HF_REPOS'))).toBe(true);
+    });
+
+    it('errors when COLORS is missing', () => {
+        const { COLORS: _, ...config } = VALID_CONFIG;
+        const errors = validateConfig(config);
+        expect(errors.some(e => e.includes('COLORS'))).toBe(true);
+    });
+
+    it('errors when COLORS is missing sub-keys', () => {
+        const config = {
+            ...VALID_CONFIG,
+            COLORS: { primary: '#92991c' },
+        };
+        const errors = validateConfig(config);
+        expect(errors.some(e => e.includes('COLORS keys'))).toBe(true);
+    });
+
+    it('errors list includes all missing fields at once', () => {
+        const config = {
+            ADDITIONAL_REPOS: [],
+            ADDITIONAL_HF_REPOS: [],
+            COLORS: VALID_CONFIG.COLORS,
+        };
+        const errors = validateConfig(config);
+        expect(errors).toContain('ORGANIZATION_NAME');
+        expect(errors).toContain('API_BASE_URL');
+        expect(errors).toContain('REFRESH_INTERVAL_DAYS');
+    });
+});

--- a/tests/validateConfig.test.js
+++ b/tests/validateConfig.test.js
@@ -3,7 +3,7 @@ import { validateConfig } from '../src/validateConfig.js';
 
 const VALID_CONFIG = {
     ORGANIZATION_NAME: 'imageomics',
-    GITHUB_ORG_NAME: 'Imageomics',
+    ORG_NAME: 'Imageomics',
     CATALOG_REPO_NAME: 'catalog',
     API_BASE_URL: 'https://huggingface.co/api/',
     REFRESH_INTERVAL_DAYS: 30,
@@ -50,6 +50,24 @@ describe('validateConfig', () => {
 
     it('errors when ORGANIZATION_NAME is empty string', () => {
         expect(validateConfig({ ...VALID_CONFIG, ORGANIZATION_NAME: '' })).toContain('ORGANIZATION_NAME');
+    });
+
+    it('errors when ORG_NAME is missing', () => {
+        const { ORG_NAME: _, ...config } = VALID_CONFIG;
+        expect(validateConfig(config)).toContain('ORG_NAME');
+    });
+
+    it('errors when ORG_NAME is empty string', () => {
+        expect(validateConfig({ ...VALID_CONFIG, ORG_NAME: '' })).toContain('ORG_NAME');
+    });
+
+    it('errors when CATALOG_REPO_NAME is missing', () => {
+        const { CATALOG_REPO_NAME: _, ...config } = VALID_CONFIG;
+        expect(validateConfig(config)).toContain('CATALOG_REPO_NAME');
+    });
+
+    it('errors when CATALOG_REPO_NAME is empty string', () => {
+        expect(validateConfig({ ...VALID_CONFIG, CATALOG_REPO_NAME: '' })).toContain('CATALOG_REPO_NAME');
     });
 
     it('errors when API_BASE_URL is missing', () => {
@@ -112,6 +130,8 @@ describe('validateConfig', () => {
         };
         const errors = validateConfig(config);
         expect(errors).toContain('ORGANIZATION_NAME');
+        expect(errors).toContain('ORG_NAME');
+        expect(errors).toContain('CATALOG_REPO_NAME');
         expect(errors).toContain('API_BASE_URL');
         expect(errors).toContain('REFRESH_INTERVAL_DAYS');
     });


### PR DESCRIPTION
Closes #76.

Config validation logic was duplicated across `main.js`, `scripts/fetch-releases.js`, and `scripts/export-tags.js`, and ran on every page load.

Extracts it into `src/validateConfig.js` and updates all three callers to use it. Adds a unit test suite and an integration test that validates the actual `public/config.yaml`. Adds a CI workflow that runs tests on push/PR to `main`, including on changes to `public/config.yaml`.