### PR TITLE
feat: decouple core features from DOM for testing

### DIFF
--- a/docs/tag-grouping-process.md
+++ b/docs/tag-grouping-process.md
@@ -20,7 +20,7 @@ const TAG_GROUPS = {
 - The **value array** lists every raw API tag that should be normalized to that key.
 - Raw tags not present in any array pass through unchanged and appear as-is in the UI.
 - Raw tags that contain a colon (e.g. `license:mit`, `format:parquet`) are automatically
-  filtered out as Hugging Face system metadata so they never reach the UI. This can be changed in [main.js](../main.js), in the `normalizeTag` function.
+  filtered out as Hugging Face system metadata so they never reach the UI. This can be changed in [src/normalizeTag.js](../src/normalizeTag.js), by removing the marked option line.
 - Raw tags are maintained and matched-against for keyword searching and do appear in repo cards.
 
 ---

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@
 import jsYaml from 'js-yaml';
 import { normalizeTag } from './src/normalizeTag.js';
 import { filterItems, sortItems } from './src/filterAndSort.js';
+import { filterNewAdditionalEntries } from './src/filterNewAdditionalEntries.js';
 
 // Start fetching config immediately when the module loads (before DOMContentLoaded)
 // so the fetch is in-flight while the DOM is being parsed.
@@ -284,12 +285,7 @@ const fetchHubItems = async (repoType) => {
         const additionalForType = ADDITIONAL_HF_REPOS.filter(entry => entry.type === repoType);
         if (additionalForType.length) {
             const existingIds = new Set(hfItems.map(item => item.id));
-            const seenRepos = new Set();
-            const toFetch = additionalForType.filter(entry => {
-                if (existingIds.has(entry.repo) || seenRepos.has(entry.repo)) return false;
-                seenRepos.add(entry.repo);
-                return true;
-            });
+            const toFetch = filterNewAdditionalEntries(existingIds, additionalForType);
 
             const fetched = await Promise.all(
                 toFetch.map(entry =>

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@
 //
 
 import jsYaml from 'js-yaml';
+import { normalizeTag } from './src/normalizeTag.js';
 
 // Start fetching config immediately when the module loads (before DOMContentLoaded)
 // so the fetch is in-flight while the DOM is being parsed.
@@ -37,24 +38,6 @@ if (typeof TAG_GROUPS !== 'undefined') {
     }
 }
 
-/**
- * Normalizes a raw tag string.
- * - Returns null for Hugging Face system metadata tags
- * - Maps known aliases to their canonical tag via TAG_GROUPS.
- * - Falls back to the lowercased original if no mapping exists.
- * @param {string} tag
- * @returns {string|null}
- */
-const normalizeTag = (tag) => {
-    const lower = String(tag).toLowerCase();
-
-    // OPTION LINE -- REMOVE IF UNWANTED
-    // Removes Hugging Face auto-generated system tags (e.g. "license:mit", "format:parquet").
-    // These are identified by the presence of a colon. To include auto-generated tags in the
-    // catalog, remove the following line.
-    if (lower.includes(':')) return null;
-    return tagLookup[lower] ?? [lower];
-};
 
 let releasesMap = {};
 
@@ -252,7 +235,7 @@ const fetchHubItems = async (repoType) => {
                     const isNew = (new Date() - createdAt) / (1000 * 60 * 60 * 24) < REFRESH_INTERVAL_DAYS;
 
                     const rawTags = (repo.topics || []).map(t => t.toLowerCase());
-                    const tags = [...new Set(rawTags.flatMap(normalizeTag).filter(Boolean))];
+                    const tags = [...new Set(rawTags.flatMap(t => normalizeTag(t, tagLookup)).filter(Boolean))];
                     const displayTags = rawTags.filter(t => !t.includes(':'));
                     tags.forEach(tag => tagsMap.code.add(tag));
 
@@ -353,7 +336,7 @@ const fetchHubItems = async (repoType) => {
 
             // Extract tags from the YAML metadata (handling different structures)
             const rawTags = (item.cardData?.tags || item.tags || []).map(t => String(t).toLowerCase());
-            const tags = [...new Set(rawTags.flatMap(normalizeTag).filter(Boolean))];
+            const tags = [...new Set(rawTags.flatMap(t => normalizeTag(t, tagLookup)).filter(Boolean))];
             const displayTags = rawTags.filter(t => !t.includes(':'));
             tags.forEach(tag => tagsMap[repoType].add(tag));
 

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@
 
 import jsYaml from 'js-yaml';
 import { normalizeTag } from './src/normalizeTag.js';
+import { filterItems, sortItems } from './src/filterAndSort.js';
 
 // Start fetching config immediately when the module loads (before DOMContentLoaded)
 // so the fetch is in-flight while the DOM is being parsed.
@@ -587,69 +588,8 @@ const applyFiltersAndSort = async (updateUrl = true) => {
         currentItems = allItems[repoType];
     }
 
-    // Step 1: Filter the items based on the search, tag, and archive filters
-    const filtered = currentItems.filter(item => {
-        const matchesSearch = item.id.toLowerCase().includes(searchTerm) ||
-            item.description?.toLowerCase().includes(searchTerm) ||
-            item.tags.some(tag => tag.toLowerCase().includes(searchTerm)) ||
-            item.rawTags?.some(tag => tag.includes(searchTerm));
-
-        const matchesTag = tagFilter === "" || item.tags.some(tag => tag.toLowerCase() === tagFilter.toLowerCase());
-
-        const matchesArchive = archiveFilter === "all" || !item.archived;
-
-        return matchesSearch && matchesTag && matchesArchive;
-    });
-
-    // Step 2: Sort the filtered items
-    let sorted = [...filtered];
-    switch (sortBy) {
-        case 'alphabetical_asc':
-            sorted.sort((a, b) => {
-                const aName = a.cardData?.pretty_name || a.cardData?.model_name || a.cardData?.title || a.id.split('/').pop();
-                const bName = b.cardData?.pretty_name || b.cardData?.model_name || b.cardData?.title || b.id.split('/').pop();
-                return aName.localeCompare(bName) || a.id.localeCompare(b.id);
-            });
-            break;
-
-        case 'alphabetical_desc':
-            sorted.sort((a, b) => {
-                const aName = a.cardData?.pretty_name || a.cardData?.model_name || a.cardData?.title || a.id.split('/').pop();
-                const bName = b.cardData?.pretty_name || b.cardData?.model_name || b.cardData?.title || b.id.split('/').pop();
-                return bName.localeCompare(aName) || b.id.localeCompare(a.id);
-            });
-            break;
-
-        case 'stars_desc':
-            sorted.sort((a, b) => {
-                const aVal = a.cardData.stars ?? a.likes ?? 0;
-                const bVal = b.cardData.stars ?? b.likes ?? 0;
-                return bVal - aVal; // highest to lowest
-            });
-            break;
-
-        case 'stars_asc':
-            sorted.sort((a, b) => {
-                const aVal = a.cardData.stars ?? a.likes ?? 0;
-                const bVal = b.cardData.stars ?? b.likes ?? 0;
-                return aVal - bVal; // lowest to highest
-            });
-            break;
-
-        case 'createdAt':
-            sorted.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-            break;
-
-        case 'lastModified':
-            sorted.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
-            break;
-
-        default: // default to lastModified logic
-            sorted.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
-            break;
-    }
-
-    // Step 3: Render the sorted and filtered list
+    const filtered = filterItems(currentItems, { searchTerm, tagFilter, archiveFilter });
+    const sorted = sortItems(filtered, sortBy);
     renderItemList(sorted, repoType);
 };
 

--- a/scripts/export-tags.js
+++ b/scripts/export-tags.js
@@ -17,6 +17,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import jsYaml from 'js-yaml';
 import { validateConfig } from '../src/validateConfig.js';
+import { filterNewAdditionalEntries } from '../src/filterNewAdditionalEntries.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -97,12 +98,7 @@ const collectHFTags = async (repoType) => {
     const additionalForType = ADDITIONAL_HF_REPOS.filter(entry => entry.type === repoType);
     if (additionalForType.length) {
         const existingIds = new Set(items.map(item => item.id));
-        const seenRepos = new Set();
-        const toFetch = additionalForType.filter(entry => {
-            if (existingIds.has(entry.repo) || seenRepos.has(entry.repo)) return false;
-            seenRepos.add(entry.repo);
-            return true;
-        });
+        const toFetch = filterNewAdditionalEntries(existingIds, additionalForType);
         const fetched = await Promise.all(
             toFetch.map(entry =>
                 get(`${API_BASE_URL}${repoType}/${entry.repo}`)

--- a/src/filterAndSort.js
+++ b/src/filterAndSort.js
@@ -46,11 +46,11 @@ export function sortItems(items, sortBy) {
             break;
 
         case 'stars_desc':
-            sorted.sort((a, b) => (b.cardData.stars ?? b.likes ?? 0) - (a.cardData.stars ?? a.likes ?? 0));
+            sorted.sort((a, b) => (b.cardData?.stars ?? b.likes ?? 0) - (a.cardData?.stars ?? a.likes ?? 0));
             break;
 
         case 'stars_asc':
-            sorted.sort((a, b) => (a.cardData.stars ?? a.likes ?? 0) - (b.cardData.stars ?? b.likes ?? 0));
+            sorted.sort((a, b) => (a.cardData?.stars ?? a.likes ?? 0) - (b.cardData?.stars ?? b.likes ?? 0));
             break;
 
         case 'createdAt':

--- a/src/filterAndSort.js
+++ b/src/filterAndSort.js
@@ -1,0 +1,67 @@
+/**
+ * Filters an array of catalog items against search, tag, and archive criteria.
+ * @param {Object[]} items
+ * @param {Object} filters
+ * @param {string} filters.searchTerm - Lowercased search string.
+ * @param {string} filters.tagFilter - Exact canonical tag to match, or "" for all.
+ * @param {string} filters.archiveFilter - "active" hides archived; "all" shows everything.
+ * @returns {Object[]}
+ */
+export function filterItems(items, { searchTerm, tagFilter, archiveFilter }) {
+    return items.filter(item => {
+        const matchesSearch = item.id.toLowerCase().includes(searchTerm) ||
+            item.description?.toLowerCase().includes(searchTerm) ||
+            item.tags.some(tag => tag.toLowerCase().includes(searchTerm)) ||
+            item.rawTags?.some(tag => tag.includes(searchTerm));
+
+        const matchesTag = tagFilter === '' || item.tags.some(tag => tag.toLowerCase() === tagFilter.toLowerCase());
+
+        const matchesArchive = archiveFilter === 'all' || !item.archived;
+
+        return matchesSearch && matchesTag && matchesArchive;
+    });
+}
+
+/**
+ * Sorts a copy of the items array by the given sort key.
+ * Supports: lastModified, createdAt, alphabetical_asc, alphabetical_desc, stars_desc, stars_asc.
+ * Unknown sort keys fall back to lastModified.
+ * @param {Object[]} items
+ * @param {string} sortBy
+ * @returns {Object[]}
+ */
+export function sortItems(items, sortBy) {
+    const sorted = [...items];
+
+    const displayName = item =>
+        item.cardData?.pretty_name || item.cardData?.model_name || item.cardData?.title || item.id.split('/').pop();
+
+    switch (sortBy) {
+        case 'alphabetical_asc':
+            sorted.sort((a, b) => displayName(a).localeCompare(displayName(b)) || a.id.localeCompare(b.id));
+            break;
+
+        case 'alphabetical_desc':
+            sorted.sort((a, b) => displayName(b).localeCompare(displayName(a)) || b.id.localeCompare(a.id));
+            break;
+
+        case 'stars_desc':
+            sorted.sort((a, b) => (b.cardData.stars ?? b.likes ?? 0) - (a.cardData.stars ?? a.likes ?? 0));
+            break;
+
+        case 'stars_asc':
+            sorted.sort((a, b) => (a.cardData.stars ?? a.likes ?? 0) - (b.cardData.stars ?? b.likes ?? 0));
+            break;
+
+        case 'createdAt':
+            sorted.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+            break;
+
+        case 'lastModified':
+        default:
+            sorted.sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
+            break;
+    }
+
+    return sorted;
+}

--- a/src/filterNewAdditionalEntries.js
+++ b/src/filterNewAdditionalEntries.js
@@ -3,8 +3,8 @@
  * - Excludes entries whose repo is already in existingIds.
  * - Excludes duplicate repo values within additionalEntries (first occurrence wins).
  * @param {Set<string>} existingIds - IDs already present in the fetched item list.
- * @param {{ repo: string }[]} additionalEntries - Candidate additional entries.
- * @returns {{ repo: string }[]}
+ * @param {{ repo: string, type: string }[]} additionalEntries - Candidate additional entries.
+ * @returns {{ repo: string, type: string }[]}
  */
 export function filterNewAdditionalEntries(existingIds, additionalEntries) {
     const seen = new Set();

--- a/src/filterNewAdditionalEntries.js
+++ b/src/filterNewAdditionalEntries.js
@@ -1,0 +1,16 @@
+/**
+ * Returns the subset of additionalEntries that should be fetched:
+ * - Excludes entries whose repo is already in existingIds.
+ * - Excludes duplicate repo values within additionalEntries (first occurrence wins).
+ * @param {Set<string>} existingIds - IDs already present in the fetched item list.
+ * @param {{ repo: string }[]} additionalEntries - Candidate additional entries.
+ * @returns {{ repo: string }[]}
+ */
+export function filterNewAdditionalEntries(existingIds, additionalEntries) {
+    const seen = new Set();
+    return additionalEntries.filter(entry => {
+        if (existingIds.has(entry.repo) || seen.has(entry.repo)) return false;
+        seen.add(entry.repo);
+        return true;
+    });
+}

--- a/src/filterNewAdditionalEntries.js
+++ b/src/filterNewAdditionalEntries.js
@@ -2,8 +2,14 @@
  * Returns the subset of additionalEntries that should be fetched:
  * - Excludes entries whose repo is already in existingIds.
  * - Excludes duplicate repo values within additionalEntries (first occurrence wins).
+ *
+ * NOTE: Deduplication is by repo ID only — entry types are not compared. Callers
+ * must pre-filter additionalEntries to a single repo type before calling this function
+ * (as both main.js and export-tags.js do via `ADDITIONAL_HF_REPOS.filter(e => e.type === repoType)`).
+ * Passing entries of mixed types could incorrectly suppress a valid entry.
+ *
  * @param {Set<string>} existingIds - IDs already present in the fetched item list.
- * @param {{ repo: string, type: string }[]} additionalEntries - Candidate additional entries.
+ * @param {{ repo: string, type: string }[]} additionalEntries - Candidate additional entries, pre-filtered to a single type.
  * @returns {{ repo: string, type: string }[]}
  */
 export function filterNewAdditionalEntries(existingIds, additionalEntries) {

--- a/src/normalizeTag.js
+++ b/src/normalizeTag.js
@@ -1,0 +1,14 @@
+/**
+ * Normalizes a raw tag string.
+ * - Returns null for Hugging Face system metadata tags (tags containing a colon).
+ * - Maps known aliases to their canonical tag(s) via tagLookup.
+ * - Falls back to the lowercased original if no mapping exists.
+ * @param {string} tag
+ * @param {Object} tagLookup - Reverse lookup map: lowercased alias → [canonical tags]
+ * @returns {string[]|null}
+ */
+export function normalizeTag(tag, tagLookup) {
+    const lower = String(tag).toLowerCase();
+    if (lower.includes(':')) return null;
+    return tagLookup[lower] ?? [lower];
+}

--- a/src/normalizeTag.js
+++ b/src/normalizeTag.js
@@ -9,6 +9,10 @@
  */
 export function normalizeTag(tag, tagLookup) {
     const lower = String(tag).toLowerCase();
+    // OPTION LINE -- REMOVE IF UNWANTED
+    // Removes Hugging Face auto-generated system tags (e.g. "license:mit", "format:parquet").
+    // These are identified by the presence of a colon. To include auto-generated tags in the
+    // catalog, remove the following line.
     if (lower.includes(':')) return null;
     return tagLookup[lower] ?? [lower];
 }

--- a/tests/filterAndSort.test.js
+++ b/tests/filterAndSort.test.js
@@ -139,6 +139,15 @@ describe('sortItems', () => {
         expect(result).toEqual(['org/alpha', 'org/zebra']);
     });
 
+    it('alphabetical_desc falls back to id when pretty_name is absent', () => {
+        const items = [
+            makeItem({ id: 'org/alpha', cardData: {} }),
+            makeItem({ id: 'org/zebra', cardData: {} }),
+        ];
+        const result = sortItems(items, 'alphabetical_desc').map(i => i.id);
+        expect(result).toEqual(['org/zebra', 'org/alpha']);
+    });
+
     it('stars_desc sorts highest stars first', () => {
         const items = [
             makeItem({ id: 'org/low', cardData: { stars: 2 } }),
@@ -158,12 +167,21 @@ describe('sortItems', () => {
         expect(result).toEqual([2, 100]);
     });
 
-    it('stars sort falls back to likes when stars is null', () => {
+    it('stars_desc falls back to likes when stars is null', () => {
         const items = [
             makeItem({ id: 'org/no-stars', cardData: { stars: null }, likes: 10 }),
             makeItem({ id: 'org/has-stars', cardData: { stars: 5 }, likes: 0 }),
         ];
         const result = sortItems(items, 'stars_desc').map(i => i.id);
+        expect(result).toEqual(['org/no-stars', 'org/has-stars']);
+    });
+
+    it('stars_asc falls back to likes when stars is null', () => {
+        const items = [
+            makeItem({ id: 'org/no-stars', cardData: { stars: null }, likes: 1 }),
+            makeItem({ id: 'org/has-stars', cardData: { stars: 5 }, likes: 0 }),
+        ];
+        const result = sortItems(items, 'stars_asc').map(i => i.id);
         expect(result).toEqual(['org/no-stars', 'org/has-stars']);
     });
 
@@ -179,18 +197,20 @@ describe('sortItems', () => {
     it('lastModified sorts most recently modified first', () => {
         const items = [
             makeItem({ id: 'org/stale', lastModified: new Date('2021-01-01') }),
+            makeItem({ id: 'org/mid', lastModified: new Date('2022-06-01') }),
             makeItem({ id: 'org/fresh', lastModified: new Date('2024-06-01') }),
         ];
         const result = sortItems(items, 'lastModified').map(i => i.id);
-        expect(result).toEqual(['org/fresh', 'org/stale']);
+        expect(result).toEqual(['org/fresh', 'org/mid', 'org/stale']);
     });
 
     it('unknown sort key defaults to lastModified order', () => {
         const items = [
             makeItem({ id: 'org/stale', lastModified: new Date('2021-01-01') }),
+            makeItem({ id: 'org/mid', lastModified: new Date('2022-06-01') }),
             makeItem({ id: 'org/fresh', lastModified: new Date('2024-06-01') }),
         ];
         const result = sortItems(items, 'not-a-real-sort').map(i => i.id);
-        expect(result).toEqual(['org/fresh', 'org/stale']);
+        expect(result).toEqual(['org/fresh', 'org/mid', 'org/stale']);
     });
 });

--- a/tests/filterAndSort.test.js
+++ b/tests/filterAndSort.test.js
@@ -195,22 +195,24 @@ describe('sortItems', () => {
     });
 
     it('lastModified sorts most recently modified first', () => {
+        // IDs are intentionally non-alphabetical relative to date order
+        // (alphabetical_asc: fresh, oldest, stale — lastModified: fresh, stale, oldest)
         const items = [
-            makeItem({ id: 'org/stale', lastModified: new Date('2021-01-01') }),
-            makeItem({ id: 'org/mid', lastModified: new Date('2022-06-01') }),
+            makeItem({ id: 'org/oldest', lastModified: new Date('2021-01-01') }),
+            makeItem({ id: 'org/stale', lastModified: new Date('2022-06-01') }),
             makeItem({ id: 'org/fresh', lastModified: new Date('2024-06-01') }),
         ];
         const result = sortItems(items, 'lastModified').map(i => i.id);
-        expect(result).toEqual(['org/fresh', 'org/mid', 'org/stale']);
+        expect(result).toEqual(['org/fresh', 'org/stale', 'org/oldest']);
     });
 
     it('unknown sort key defaults to lastModified order', () => {
         const items = [
-            makeItem({ id: 'org/stale', lastModified: new Date('2021-01-01') }),
-            makeItem({ id: 'org/mid', lastModified: new Date('2022-06-01') }),
+            makeItem({ id: 'org/oldest', lastModified: new Date('2021-01-01') }),
+            makeItem({ id: 'org/stale', lastModified: new Date('2022-06-01') }),
             makeItem({ id: 'org/fresh', lastModified: new Date('2024-06-01') }),
         ];
         const result = sortItems(items, 'not-a-real-sort').map(i => i.id);
-        expect(result).toEqual(['org/fresh', 'org/mid', 'org/stale']);
+        expect(result).toEqual(['org/fresh', 'org/stale', 'org/oldest']);
     });
 });

--- a/tests/filterAndSort.test.js
+++ b/tests/filterAndSort.test.js
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import { filterItems, sortItems } from '../src/filterAndSort.js';
+
+// Minimal item factory — only the fields filterItems/sortItems actually read.
+const makeItem = (overrides = {}) => ({
+    id: 'org/repo',
+    description: 'A test repository.',
+    tags: ['animals', 'birds'],
+    rawTags: ['bird', 'animal'],
+    archived: false,
+    cardData: { pretty_name: 'Repo', stars: null },
+    likes: 0,
+    createdAt: new Date('2023-01-01'),
+    lastModified: new Date('2023-06-01'),
+    ...overrides,
+});
+
+// ─── filterItems ─────────────────────────────────────────────────────────────
+
+describe('filterItems', () => {
+    const defaults = { searchTerm: '', tagFilter: '', archiveFilter: 'active' };
+
+    it('returns all items when no filters are active', () => {
+        const items = [makeItem(), makeItem({ id: 'org/other' })];
+        expect(filterItems(items, defaults)).toHaveLength(2);
+    });
+
+    it('filters by id substring (searchTerm is pre-lowercased)', () => {
+        const items = [
+            makeItem({ id: 'org/fish-data', tags: [], rawTags: [] }),
+            makeItem({ id: 'org/plant-model', tags: [], rawTags: [] }),
+        ];
+        expect(filterItems(items, { ...defaults, searchTerm: 'fish' })).toHaveLength(1);
+        expect(filterItems(items, { ...defaults, searchTerm: 'plant' })).toHaveLength(1);
+        expect(filterItems(items, { ...defaults, searchTerm: 'org' })).toHaveLength(2);
+    });
+
+    it('filters by description substring', () => {
+        const items = [
+            makeItem({ description: 'Images of butterflies' }),
+            makeItem({ description: 'Images of dogs' }),
+        ];
+        expect(filterItems(items, { ...defaults, searchTerm: 'butterfl' })).toHaveLength(1);
+    });
+
+    it('filters by normalized tag substring', () => {
+        const items = [
+            makeItem({ tags: ['machine-learning', 'biology'] }),
+            makeItem({ tags: ['computer-vision'] }),
+        ];
+        expect(filterItems(items, { ...defaults, searchTerm: 'bio' })).toHaveLength(1);
+    });
+
+    it('filters by rawTag substring', () => {
+        const items = [
+            makeItem({ rawTags: ['heliconius-erato'] }),
+            makeItem({ rawTags: ['bird'] }),
+        ];
+        expect(filterItems(items, { ...defaults, searchTerm: 'heliconius' })).toHaveLength(1);
+    });
+
+    it('returns no items when search matches nothing', () => {
+        const items = [makeItem(), makeItem({ id: 'org/other' })];
+        expect(filterItems(items, { ...defaults, searchTerm: 'zzznomatch' })).toHaveLength(0);
+    });
+
+    it('filters by exact tag (case-insensitive)', () => {
+        const items = [
+            makeItem({ tags: ['animals', 'birds'] }),
+            makeItem({ tags: ['machine-learning'] }),
+        ];
+        expect(filterItems(items, { ...defaults, tagFilter: 'birds' })).toHaveLength(1);
+        expect(filterItems(items, { ...defaults, tagFilter: 'BIRDS' })).toHaveLength(1);
+    });
+
+    it('tag filter does not match partial tags', () => {
+        const items = [makeItem({ tags: ['machine-learning'] })];
+        expect(filterItems(items, { ...defaults, tagFilter: 'machine' })).toHaveLength(0);
+    });
+
+    it('archiveFilter active hides archived items', () => {
+        const items = [makeItem(), makeItem({ archived: true })];
+        expect(filterItems(items, { ...defaults, archiveFilter: 'active' })).toHaveLength(1);
+    });
+
+    it('archiveFilter all includes archived items', () => {
+        const items = [makeItem(), makeItem({ archived: true })];
+        expect(filterItems(items, { ...defaults, archiveFilter: 'all' })).toHaveLength(2);
+    });
+
+    it('all three filters combine correctly', () => {
+        const items = [
+            makeItem({ id: 'org/fish-data', tags: ['biology'], archived: false }),
+            makeItem({ id: 'org/fish-archive', tags: ['biology'], archived: true }),
+            makeItem({ id: 'org/bird-data', tags: ['biology'], archived: false }),
+        ];
+        const result = filterItems(items, { searchTerm: 'fish', tagFilter: 'biology', archiveFilter: 'active' });
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('org/fish-data');
+    });
+});
+
+// ─── sortItems ────────────────────────────────────────────────────────────────
+
+describe('sortItems', () => {
+    it('does not mutate the input array', () => {
+        const items = [makeItem({ id: 'org/b' }), makeItem({ id: 'org/a' })];
+        const original = [...items];
+        sortItems(items, 'alphabetical_asc');
+        expect(items).toEqual(original);
+    });
+
+    it('alphabetical_asc sorts by display name A→Z', () => {
+        const items = [
+            makeItem({ id: 'org/c', cardData: { pretty_name: 'Zebra', stars: null } }),
+            makeItem({ id: 'org/a', cardData: { pretty_name: 'Alpha', stars: null } }),
+            makeItem({ id: 'org/b', cardData: { pretty_name: 'Mango', stars: null } }),
+        ];
+        const result = sortItems(items, 'alphabetical_asc').map(i => i.cardData.pretty_name);
+        expect(result).toEqual(['Alpha', 'Mango', 'Zebra']);
+    });
+
+    it('alphabetical_desc sorts by display name Z→A', () => {
+        const items = [
+            makeItem({ id: 'org/a', cardData: { pretty_name: 'Alpha', stars: null } }),
+            makeItem({ id: 'org/b', cardData: { pretty_name: 'Mango', stars: null } }),
+            makeItem({ id: 'org/c', cardData: { pretty_name: 'Zebra', stars: null } }),
+        ];
+        const result = sortItems(items, 'alphabetical_desc').map(i => i.cardData.pretty_name);
+        expect(result).toEqual(['Zebra', 'Mango', 'Alpha']);
+    });
+
+    it('alphabetical_asc falls back to id when pretty_name is absent', () => {
+        const items = [
+            makeItem({ id: 'org/zebra', cardData: {} }),
+            makeItem({ id: 'org/alpha', cardData: {} }),
+        ];
+        const result = sortItems(items, 'alphabetical_asc').map(i => i.id);
+        expect(result).toEqual(['org/alpha', 'org/zebra']);
+    });
+
+    it('stars_desc sorts highest stars first', () => {
+        const items = [
+            makeItem({ id: 'org/low', cardData: { stars: 2 } }),
+            makeItem({ id: 'org/high', cardData: { stars: 100 } }),
+            makeItem({ id: 'org/mid', cardData: { stars: 50 } }),
+        ];
+        const result = sortItems(items, 'stars_desc').map(i => i.cardData.stars);
+        expect(result).toEqual([100, 50, 2]);
+    });
+
+    it('stars_asc sorts lowest stars first', () => {
+        const items = [
+            makeItem({ id: 'org/high', cardData: { stars: 100 } }),
+            makeItem({ id: 'org/low', cardData: { stars: 2 } }),
+        ];
+        const result = sortItems(items, 'stars_asc').map(i => i.cardData.stars);
+        expect(result).toEqual([2, 100]);
+    });
+
+    it('stars sort falls back to likes when stars is null', () => {
+        const items = [
+            makeItem({ id: 'org/no-stars', cardData: { stars: null }, likes: 10 }),
+            makeItem({ id: 'org/has-stars', cardData: { stars: 5 }, likes: 0 }),
+        ];
+        const result = sortItems(items, 'stars_desc').map(i => i.id);
+        expect(result).toEqual(['org/no-stars', 'org/has-stars']);
+    });
+
+    it('createdAt sorts newest creation first', () => {
+        const items = [
+            makeItem({ id: 'org/old', createdAt: new Date('2020-01-01') }),
+            makeItem({ id: 'org/new', createdAt: new Date('2024-01-01') }),
+        ];
+        const result = sortItems(items, 'createdAt').map(i => i.id);
+        expect(result).toEqual(['org/new', 'org/old']);
+    });
+
+    it('lastModified sorts most recently modified first', () => {
+        const items = [
+            makeItem({ id: 'org/stale', lastModified: new Date('2021-01-01') }),
+            makeItem({ id: 'org/fresh', lastModified: new Date('2024-06-01') }),
+        ];
+        const result = sortItems(items, 'lastModified').map(i => i.id);
+        expect(result).toEqual(['org/fresh', 'org/stale']);
+    });
+
+    it('unknown sort key defaults to lastModified order', () => {
+        const items = [
+            makeItem({ id: 'org/stale', lastModified: new Date('2021-01-01') }),
+            makeItem({ id: 'org/fresh', lastModified: new Date('2024-06-01') }),
+        ];
+        const result = sortItems(items, 'not-a-real-sort').map(i => i.id);
+        expect(result).toEqual(['org/fresh', 'org/stale']);
+    });
+});

--- a/tests/filterAndSort.test.js
+++ b/tests/filterAndSort.test.js
@@ -123,8 +123,8 @@ describe('sortItems', () => {
     it('alphabetical_desc sorts by display name Z→A', () => {
         const items = [
             makeItem({ id: 'org/a', cardData: { pretty_name: 'Alpha', stars: null } }),
-            makeItem({ id: 'org/b', cardData: { pretty_name: 'Mango', stars: null } }),
-            makeItem({ id: 'org/c', cardData: { pretty_name: 'Zebra', stars: null } }),
+            makeItem({ id: 'org/c', cardData: { pretty_name: 'Mango', stars: null } }),
+            makeItem({ id: 'org/b', cardData: { pretty_name: 'Zebra', stars: null } }),
         ];
         const result = sortItems(items, 'alphabetical_desc').map(i => i.cardData.pretty_name);
         expect(result).toEqual(['Zebra', 'Mango', 'Alpha']);

--- a/tests/filterAndSort.test.js
+++ b/tests/filterAndSort.test.js
@@ -112,9 +112,9 @@ describe('sortItems', () => {
 
     it('alphabetical_asc sorts by display name A→Z', () => {
         const items = [
-            makeItem({ id: 'org/c', cardData: { pretty_name: 'Zebra', stars: null } }),
+            makeItem({ id: 'org/b', cardData: { pretty_name: 'Zebra', stars: null } }),
             makeItem({ id: 'org/a', cardData: { pretty_name: 'Alpha', stars: null } }),
-            makeItem({ id: 'org/b', cardData: { pretty_name: 'Mango', stars: null } }),
+            makeItem({ id: 'org/c', cardData: { pretty_name: 'Mango', stars: null } }),
         ];
         const result = sortItems(items, 'alphabetical_asc').map(i => i.cardData.pretty_name);
         expect(result).toEqual(['Alpha', 'Mango', 'Zebra']);

--- a/tests/filterNewAdditionalEntries.test.js
+++ b/tests/filterNewAdditionalEntries.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { filterNewAdditionalEntries } from '../src/filterNewAdditionalEntries.js';
+
+describe('filterNewAdditionalEntries', () => {
+    it('returns all entries when existingIds is empty', () => {
+        const entries = [
+            { repo: 'org/a', type: 'datasets' },
+            { repo: 'org/b', type: 'models' },
+        ];
+        expect(filterNewAdditionalEntries(new Set(), entries)).toEqual(entries);
+    });
+
+    it('returns empty array for empty additionalEntries', () => {
+        expect(filterNewAdditionalEntries(new Set(['org/a']), [])).toEqual([]);
+    });
+
+    it('excludes entries whose repo already exists in existingIds', () => {
+        const existingIds = new Set(['org/existing']);
+        const entries = [
+            { repo: 'org/existing', type: 'datasets' },
+            { repo: 'org/new', type: 'datasets' },
+        ];
+        const result = filterNewAdditionalEntries(existingIds, entries);
+        expect(result).toEqual([{ repo: 'org/new', type: 'datasets' }]);
+    });
+
+    it('excludes all entries when all repos are already in existingIds', () => {
+        const existingIds = new Set(['org/a', 'org/b']);
+        const entries = [
+            { repo: 'org/a', type: 'datasets' },
+            { repo: 'org/b', type: 'models' },
+        ];
+        expect(filterNewAdditionalEntries(existingIds, entries)).toEqual([]);
+    });
+
+    it('deduplicates within additionalEntries — first occurrence wins', () => {
+        const entries = [
+            { repo: 'org/dup', type: 'datasets' },
+            { repo: 'org/dup', type: 'models' },
+            { repo: 'org/unique', type: 'datasets' },
+        ];
+        const result = filterNewAdditionalEntries(new Set(), entries);
+        expect(result).toHaveLength(2);
+        expect(result[0]).toEqual({ repo: 'org/dup', type: 'datasets' });
+        expect(result[1]).toEqual({ repo: 'org/unique', type: 'datasets' });
+    });
+
+    it('does not mutate the existingIds set', () => {
+        const existingIds = new Set(['org/a']);
+        const entries = [{ repo: 'org/b', type: 'datasets' }];
+        filterNewAdditionalEntries(existingIds, entries);
+        expect(existingIds.size).toBe(1);
+        expect(existingIds.has('org/b')).toBe(false);
+    });
+
+    it('handles mixed existing and duplicate entries together', () => {
+        const existingIds = new Set(['org/exists']);
+        const entries = [
+            { repo: 'org/exists', type: 'datasets' },
+            { repo: 'org/new', type: 'datasets' },
+            { repo: 'org/new', type: 'models' },
+        ];
+        const result = filterNewAdditionalEntries(existingIds, entries);
+        expect(result).toEqual([{ repo: 'org/new', type: 'datasets' }]);
+    });
+});

--- a/tests/filterNewAdditionalEntries.test.js
+++ b/tests/filterNewAdditionalEntries.test.js
@@ -28,7 +28,7 @@ describe('filterNewAdditionalEntries', () => {
         const existingIds = new Set(['org/a', 'org/b']);
         const entries = [
             { repo: 'org/a', type: 'datasets' },
-            { repo: 'org/b', type: 'models' },
+            { repo: 'org/b', type: 'datasets' },
         ];
         expect(filterNewAdditionalEntries(existingIds, entries)).toEqual([]);
     });
@@ -36,7 +36,7 @@ describe('filterNewAdditionalEntries', () => {
     it('deduplicates within additionalEntries — first occurrence wins', () => {
         const entries = [
             { repo: 'org/dup', type: 'datasets' },
-            { repo: 'org/dup', type: 'models' },
+            { repo: 'org/dup', type: 'datasets' },
             { repo: 'org/unique', type: 'datasets' },
         ];
         const result = filterNewAdditionalEntries(new Set(), entries);
@@ -58,7 +58,7 @@ describe('filterNewAdditionalEntries', () => {
         const entries = [
             { repo: 'org/exists', type: 'datasets' },
             { repo: 'org/new', type: 'datasets' },
-            { repo: 'org/new', type: 'models' },
+            { repo: 'org/new', type: 'datasets' },
         ];
         const result = filterNewAdditionalEntries(existingIds, entries);
         expect(result).toEqual([{ repo: 'org/new', type: 'datasets' }]);

--- a/tests/normalizeTag.test.js
+++ b/tests/normalizeTag.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeTag } from '../src/normalizeTag.js';
+
+// tagLookup format: lowercased alias → [canonical tags]
+const LOOKUP = {
+    bird: ['animals'],
+    birds: ['animals'],
+    butterfly: ['animals', 'insects'],
+    butterflies: ['animals', 'insects'],
+    beetle: ['insects'],
+    fish: ['animals'],
+};
+
+describe('normalizeTag', () => {
+    it('returns null for tags containing a colon', () => {
+        expect(normalizeTag('license:mit', LOOKUP)).toBeNull();
+        expect(normalizeTag('format:parquet', LOOKUP)).toBeNull();
+        expect(normalizeTag(':leadingcolon', LOOKUP)).toBeNull();
+        expect(normalizeTag('trailingcolon:', LOOKUP)).toBeNull();
+    });
+
+    it('returns the canonical tag in an array for a known alias', () => {
+        expect(normalizeTag('bird', LOOKUP)).toEqual(['animals']);
+        expect(normalizeTag('birds', LOOKUP)).toEqual(['animals']);
+    });
+
+    it('returns multiple canonical tags when an alias maps to multiple groups', () => {
+        expect(normalizeTag('butterfly', LOOKUP)).toEqual(['animals', 'insects']);
+        expect(normalizeTag('butterflies', LOOKUP)).toEqual(['animals', 'insects']);
+    });
+
+    it('lowercases the input before lookup', () => {
+        expect(normalizeTag('BIRD', LOOKUP)).toEqual(['animals']);
+        expect(normalizeTag('Bird', LOOKUP)).toEqual(['animals']);
+        expect(normalizeTag('BUTTERFLY', LOOKUP)).toEqual(['animals', 'insects']);
+    });
+
+    it('returns the lowercased tag in a single-element array when no mapping exists', () => {
+        expect(normalizeTag('unknown-tag', LOOKUP)).toEqual(['unknown-tag']);
+        expect(normalizeTag('UNKNOWN', LOOKUP)).toEqual(['unknown']);
+    });
+
+    it('handles an empty tagLookup (passthrough)', () => {
+        expect(normalizeTag('some-tag', {})).toEqual(['some-tag']);
+    });
+
+    it('coerces non-string input to string', () => {
+        expect(normalizeTag(123, {})).toEqual(['123']);
+        expect(normalizeTag(true, {})).toEqual(['true']);
+    });
+});


### PR DESCRIPTION
Closes #89.

`normalizeTag`, filter/sort logic, and HF additional-repo deduplication were all inline in `main.js` (and `export-tags.js`), either closing over globals or reading from the DOM, making them untestable in isolation.

Extracts each into a pure function in `src/`:
- `normalizeTag.js` - accepts `tagLookup` as a parameter instead of reading the module global
- `filterAndSort.js` - `filterItems` and `sortItems` take plain data, no DOM reads
- `filterNewAdditionalEntries.js` - shared by both `main.js` and `export-tags.js`, replacing duplicated inline logic

Adds a unit test suite for each extracted module (56 tests total).