### PR TITLE
Add import for getPlatformDisplay function

### DIFF
--- a/scripts/export-tags.js
+++ b/scripts/export-tags.js
@@ -18,6 +18,7 @@ import { fileURLToPath } from 'url';
 import jsYaml from 'js-yaml';
 import { validateConfig } from '../src/validateConfig.js';
 import { getPlatformApiUrls } from '../src/defineApiUrls.js';
+import { getPlatformDisplay } from '../src/defineRibbonVals.js';
 import { filterNewAdditionalEntries } from '../src/filterNewAdditionalEntries.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
This was a suggestion from Copilot to improve log messaging; displayName is set from `src/defineRibbonVals.js`, but the import was missed.

This should fix the [weekly tag scan workflow error](https://github.com/Imageomics/catalog/actions/runs/26024158812).