### PR TITLE
Clarify demo (HF space) jargon

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -14,13 +14,14 @@
           "affiliation": "The Ohio State University"
       }
     ],
-    "description": "<p>Catalog app for Imageomics code, data, models, and spaces hosted on GitHub and Hugging Face. It was designed for improved discoverability and searchability of Imageomics products, and the content is updated in real-time through calls to the GitHub and Hugging Face APIs.</p>\n<p>Catalog website: <a href=\"https://imageomics.github.io/catalog/\">imageomics.github.io/catalog/</a>.</p>\n<p>The repository also serves as a template for others looking to create a similar website to catalog their group's code, data, models, and demos.</p>",
+    "description": "<p>Catalog app for Imageomics code, data, models, and demos hosted on GitHub and Hugging Face. It was designed for improved discoverability and searchability of Imageomics products, and the content is updated in real-time through calls to the GitHub and Hugging Face APIs.</p>\n<p>Catalog website: <a href=\"https://imageomics.github.io/catalog/\">imageomics.github.io/catalog/</a>.</p>\n<p>The repository also serves as a template for others looking to create a similar website to catalog their group's code, data, models, and demos.</p>",
     "keywords": [
       "imageomics",
       "code",
       "data",
       "models",
       "spaces",
+      "demos",
       "GitHub",
       "Hugging Face",
       "APIs",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance for AI coding agents (e.g., GitHub Copilot) working 
 
 ## Project Overview
 
-This is a **template repository** for a web-based catalog of an organization's public code, datasets, models, and spaces. It fetches live data from the code repository platform (such as GitHub) API and the platform API for hosting datasets and models (Hugging Face) and renders a searchable, filterable catalog page as a static site via GitHub Pages. The default setup is for the Imageomics Organization's GitHub and Hugging Face products.
+This is a **template repository** for a web-based catalog of an organization's public code, datasets, models, and demos. It fetches live data from the code repository platform (such as GitHub) API and the platform API for hosting datasets and models (Hugging Face) and renders a searchable, filterable catalog page as a static site via GitHub Pages. The default setup is for the Imageomics Organization's GitHub and Hugging Face products.
 
 ## Critical: Templated Design
 
@@ -50,7 +50,7 @@ Resource type | List (org) URL | Detail (single repo) URL
 ---|---|---
 Datasets | `{API_BASE_URL}datasets?author={org}&full=true` | `{API_BASE_URL}datasets/{owner}/{repo}`
 Models | `{API_BASE_URL}models?author={org}&full=true` | `{API_BASE_URL}models/{owner}/{repo}`
-Spaces | `{API_BASE_URL}spaces?author={org}&full=true` | `{API_BASE_URL}spaces/{owner}/{repo}`
+Spaces (demos) | `{API_BASE_URL}spaces?author={org}&full=true` | `{API_BASE_URL}spaces/{owner}/{repo}`
 
 `API_BASE_URL` defaults to `https://huggingface.co/api/` (set in `config.yaml`).
 
@@ -60,7 +60,7 @@ Resource type | Link URL
 ---|---
 Datasets | `https://huggingface.co/datasets/{owner}/{repo}`
 Models | `https://huggingface.co/{owner}/{repo}` *(no `/models/` prefix)*
-Spaces | `https://huggingface.co/spaces/{owner}/{repo}`
+Spaces (demos) | `https://huggingface.co/spaces/{owner}/{repo}`
 
 ### Models Require a Secondary Per-Model Fetch
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-abstract: "Catalog app for Imageomics code, data, models, and spaces hosted on GitHub and Hugging Face. It was designed for improved discoverability and searchability of Imageomics products, and the content is updated in real-time through calls to the GitHub and Hugging Face APIs. The repository also serves as a template for others looking to create a similar website to catalog their group's code, data, models, and demos."
+abstract: "Catalog app for Imageomics code, data, models, and demos hosted on GitHub and Hugging Face. It was designed for improved discoverability and searchability of Imageomics products, and the content is updated in real-time through calls to the GitHub and Hugging Face APIs. The repository also serves as a template for others looking to create a similar website to catalog their group's code, data, models, and demos."
 authors:
 - family-names: "Campolongo"
   given-names: "Elizabeth G."
@@ -25,6 +25,7 @@ keywords:
   - data
   - models
   - spaces
+  - demos
   - "GitHub"
   - "Hugging Face"
   - APIs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ Thank you for your interest in contributing to the catalog! This document outlin
 
 ## Overview
 
-This catalog is built with JavaScript and relies on API calls to code, data, model, and spaces repositories to populate the web app in real time. Deployment only requires a static site-capable web server. The [Imageomics instance](https://catalog.imageomics.org) is currently deployed via GitHub Pages.
+This catalog is built with JavaScript and relies on API calls to code, data, model, and demo repositories to populate the web app in real time. Deployment only requires a static site-capable web server. The [Imageomics instance](https://catalog.imageomics.org) is currently deployed via GitHub Pages.
 
-This is a template repository designed to be copied (with "Use this Template") and customized by different organizations to present their code, data, models, and spaces in a dynamic, searchable site. The default setup is for the Imageomics Institute's GitHub and Hugging Face products.
+This is a template repository designed to be copied (with "Use this Template") and customized by different organizations to present their code, data, models, and demos in a dynamic, searchable site. The default setup is for the Imageomics Institute's GitHub and Hugging Face products.
 
 ## Getting Started
 
@@ -24,7 +24,7 @@ UI features should be tested locally through running a preview.
 
 ## Coding Style, Conventions, and Project Structure
 
-Please refer to our [AGENTS.md](AGENTS.md). This also includes special notes on key differences between the repo types (datasets, models, and spaces) in Hugging Face API calls and returns,  as well as important considerations for the templated design of this repository.
+Please refer to our [AGENTS.md](AGENTS.md). This also includes special notes on key differences between the repo types (datasets, models, and spaces/demos) in Hugging Face API calls and returns,  as well as important considerations for the templated design of this repository.
 
 ## Contribution Process
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Imageomics Catalog [![DOI](https://zenodo.org/badge/1054290236.svg)](https://doi.org/10.5281/zenodo.17602801)
 
-Repository for web-based catalog of Imageomics code, data, models, and spaces. This template catalog is designed to fetch live data from an organization's code repository platform (e.g., GitHub) API and dataset, model, and spaces repository data from the Hugging Face API to render a searchable, filterable catalog page as a static site via GitHub Pages. The default setup is for the Imageomics Institute's [GitHub](https://github.com/Imageomics) and [Hugging Face](https://huggingface.co/imageomics) organizations.
+Repository for web-based catalog of Imageomics code, data, models, and demos. This template catalog is designed to fetch live data from an organization's code repository platform (e.g., GitHub) API and dataset, model, and spaces (demos) repository data from the Hugging Face API to render a searchable, filterable catalog page as a static site via GitHub Pages. The default setup is for the Imageomics Institute's [GitHub](https://github.com/Imageomics) and [Hugging Face](https://huggingface.co/imageomics) organizations.
 
 For those interested in creating a similar catalog website or contributing to this template, instructions for use and personalization are provided below, under [How to Use this Template](#how-to-use-this-template). More background on this site's creation is provided in the [docs](docs/).
 

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
                             <option value="code">Code</option>
                             <option value="datasets">Datasets</option>
                             <option value="models">Models</option>
-                            <option value="spaces">Spaces (Demos)</option>
+                            <option value="spaces">Demos</option>
                         </select>
                     </div>
 

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
                             <option value="code">Code</option>
                             <option value="datasets">Datasets</option>
                             <option value="models">Models</option>
-                            <option value="spaces">Spaces</option>
+                            <option value="spaces">Spaces (Demos)</option>
                         </select>
                     </div>
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "catalog",
   "version": "4.3.0",
-  "description": "Repository for web-based Imageomics code, data, model, and spaces catalog. This catalog is designed to use the GitHub API for searching all code repositories created under the [Imageomics GitHub Organization](https://github.com/Imageomics) and the Hugging Face API for searching all dataset, model, and spaces repositories created under the [Imageomics Hugging Face Organization](https://huggingface.co/imageomics).",
+  "description": "Repository for web-based Imageomics code, data, model, and demos catalog. This catalog is designed to use the GitHub API for searching all code repositories created under the [Imageomics GitHub Organization](https://github.com/Imageomics) and the Hugging Face API for searching all dataset, model, and spaces repositories created under the [Imageomics Hugging Face Organization](https://huggingface.co/imageomics).",
   "main": "main.js",
   "scripts": {
     "dev": "vite",
@@ -20,6 +20,7 @@
     "data",
     "models",
     "spaces",
+    "demos",
     "GitHub",
     "Hugging Face",
     "APIs",

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -9,7 +9,7 @@ CATALOG_REPO_NAME: catalog          # Repository name for the catalog itself (us
 
 # Branding
 CATALOG_TITLE: Imageomics Catalog
-CATALOG_DESCRIPTION: "Explore and discover public code, datasets, models, and spaces (demos)."
+CATALOG_DESCRIPTION: "Explore and discover public code, datasets, models, and demos."
 LOGO_URL: "https://github.com/Imageomics/Imageomics-guide/raw/3478acc0068a87a5604069d04a29bdb0795c2045/docs/logos/Imageomics_logo_butterfly.png"
 FAVICON_URL: "https://github.com/Imageomics/Imageomics-guide/raw/3478acc0068a87a5604069d04a29bdb0795c2045/docs/logos/Imageomics_logo_butterfly.png"
 

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -24,7 +24,7 @@ COLORS:
 # API & Behavior Settings
 # Codebase platform for API calls and link generation. Supported values: "github" or "codeberg", pending: "gitlab".
 PLATFORM: github
-# Dataset, model, and space (demo) default: Hugging Face, other platforms would require a custom module
+# Dataset, model, and demo default: Hugging Face, other platforms would require a custom module
 API_BASE_URL: "https://huggingface.co/api/"
 # Define "new" repository criteria
 REFRESH_INTERVAL_DAYS: 30
@@ -43,7 +43,7 @@ ADDITIONAL_REPOS:
   - "yoohj0416/predictbeetle"
 
 # Array of Hugging Face repos from outside the org to include.
-# Each entry must specify "repo" (owner/name) and "type" (datasets, models, or spaces).
+# Each entry must specify "repo" (owner/name) and "type" (datasets, models, or spaces/demos).
 # Organization names are case-sensitive in the Hugging Face API.
 # ADDITIONAL_HF_REPOS:
 #   - repo: "user/dataset-name"

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -9,7 +9,7 @@ CATALOG_REPO_NAME: catalog          # Repository name for the catalog itself (us
 
 # Branding
 CATALOG_TITLE: Imageomics Catalog
-CATALOG_DESCRIPTION: "Explore and discover public code, datasets, models, and spaces."
+CATALOG_DESCRIPTION: "Explore and discover public code, datasets, models, and spaces (demos)."
 LOGO_URL: "https://github.com/Imageomics/Imageomics-guide/raw/3478acc0068a87a5604069d04a29bdb0795c2045/docs/logos/Imageomics_logo_butterfly.png"
 FAVICON_URL: "https://github.com/Imageomics/Imageomics-guide/raw/3478acc0068a87a5604069d04a29bdb0795c2045/docs/logos/Imageomics_logo_butterfly.png"
 


### PR DESCRIPTION
Add "demos" in parentheses next to "spaces" in catalog byline and the dropdown for clarification. This was discussed offline with @dboghrat as a simpler solution, since the proposed text was too long.

<img height="549" alt="Screenshot of top of catalog with dropdown filter by repo type. the two times spaces are mentioned, demos is included in parentheses" src="https://github.com/user-attachments/assets/6016f532-d9ab-4a96-989f-23596a4705f0" />



Closes #122.