### PR TITLE
Prep provenance files for major release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -23,6 +23,8 @@
       "spaces",
       "demos",
       "GitHub",
+      "GitLab",
+      "Codeberg",
       "Hugging Face",
       "APIs",
       "inventory",
@@ -32,9 +34,9 @@
       "searchability"
     ],
     "title": "Imageomics Catalog",
-    "version": "4.3.0",
+    "version": "5.0.0",
     "license": "MIT",
-    "publication_date": "2026-07-08",
+    "publication_date": "2026-08-18",
     "grants": [
         {
             "id": "021nxhr62::2118240"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,14 +11,14 @@ authors:
   given-names: "Balaji"
   affiliation: "The Ohio State University"
 cff-version: 1.2.0
-date-released: "2026-07-08"
+date-released: "2026-08-18"
 identifiers:
-  - description: "The GitHub release URL of tag v4.3.0."
+  - description: "The GitHub release URL of tag v5.0.0."
     type: url
-    value: "https://github.com/Imageomics/catalog/releases/tag/v4.3.0"
-  - description: "The GitHub URL of the commit tagged with v4.3.0."
+    value: "https://github.com/Imageomics/catalog/releases/tag/v5.0.0"
+  - description: "The GitHub URL of the commit tagged with v5.0.0."
     type: url
-    value: "https://github.com/Imageomics/catalog/tree/287b1a702ca3c4fd4c55ceb1949f8c1fb3e2b85b" # Update on release
+    value: "https://github.com/Imageomics/catalog/tree/<commit-hash>" # Update on release
 keywords:
   - imageomics
   - code
@@ -27,6 +27,8 @@ keywords:
   - spaces
   - demos
   - "GitHub"
+  - "GitLab"
+  - "Codeberg"
   - "Hugging Face"
   - APIs
   - inventory
@@ -38,6 +40,6 @@ license: MIT
 message: "If you use this software, please cite it as below."
 repository-code: "https://github.com/Imageomics/catalog"
 title: "Imageomics Catalog"
-version: "4.3.0"
+version: "5.0.0"
 doi: "10.5281/zenodo.17602801"
 type: software

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "catalog",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "catalog",
-      "version": "4.3.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^5.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catalog",
-  "version": "4.3.0",
+  "version": "5.0.0",
   "description": "Repository for web-based Imageomics code, data, model, and demos catalog. This catalog is designed to use the GitHub API for searching all code repositories created under the [Imageomics GitHub Organization](https://github.com/Imageomics) and the Hugging Face API for searching all dataset, model, and spaces repositories created under the [Imageomics Hugging Face Organization](https://huggingface.co/imageomics).",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Set to release tomorrow. 

Major version: Backend refactoring, the addition of GitLab and Codeberg as optional code platforms, change to "demo" instead of HF-specific "spaces", and addition of a results counter.

Updated:

- [x] Citation file
- [x] Zenodo metadata
- [x] `package.json` then ran `npm install` to update `package-lock.json`