### PR TITLE
Prep provenance files for patch release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -34,9 +34,9 @@
       "searchability"
     ],
     "title": "Imageomics Catalog",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "license": "MIT",
-    "publication_date": "2026-08-18",
+    "publication_date": "2026-08-24",
     "grants": [
         {
             "id": "021nxhr62::2118240"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,14 +11,14 @@ authors:
   given-names: "Balaji"
   affiliation: "The Ohio State University"
 cff-version: 1.2.0
-date-released: "2026-08-18"
+date-released: "2026-08-24"
 identifiers:
-  - description: "The GitHub release URL of tag v5.0.0."
+  - description: "The GitHub release URL of tag v5.0.1."
     type: url
-    value: "https://github.com/Imageomics/catalog/releases/tag/v5.0.0"
-  - description: "The GitHub URL of the commit tagged with v5.0.0."
+    value: "https://github.com/Imageomics/catalog/releases/tag/v5.0.1"
+  - description: "The GitHub URL of the commit tagged with v5.0.1."
     type: url
-    value: "https://github.com/Imageomics/catalog/tree/027f949f788acf4ffaffd32d5c4ac95629fa760c" # Update on release
+    value: "https://github.com/Imageomics/catalog/tree/<commit-hash>" # Update on release
 keywords:
   - imageomics
   - code
@@ -40,6 +40,6 @@ license: MIT
 message: "If you use this software, please cite it as below."
 repository-code: "https://github.com/Imageomics/catalog"
 title: "Imageomics Catalog"
-version: "5.0.0"
+version: "5.0.1"
 doi: "10.5281/zenodo.17602801"
 type: software

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "catalog",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "catalog",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^5.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catalog",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Repository for web-based Imageomics code, data, model, and demos catalog. This catalog is designed to use the GitHub API for searching all code repositories created under the [Imageomics GitHub Organization](https://github.com/Imageomics) and the Hugging Face API for searching all dataset, model, and spaces repositories created under the [Imageomics Hugging Face Organization](https://huggingface.co/imageomics).",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Bug-fix from #139.

Updated:

- [x] Citation file
- [x] Zenodo metadata
- [x] `package.json` then ran `npm install` to update `package-lock.json`