### PR TITLE
Bug-fix: Tag Export patch release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -34,9 +34,9 @@
       "searchability"
     ],
     "title": "Imageomics Catalog",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "license": "MIT",
-    "publication_date": "2026-08-18",
+    "publication_date": "2026-08-24",
     "grants": [
         {
             "id": "021nxhr62::2118240"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,14 +11,14 @@ authors:
   given-names: "Balaji"
   affiliation: "The Ohio State University"
 cff-version: 1.2.0
-date-released: "2026-08-18"
+date-released: "2026-08-24"
 identifiers:
-  - description: "The GitHub release URL of tag v5.0.0."
+  - description: "The GitHub release URL of tag v5.0.1."
     type: url
-    value: "https://github.com/Imageomics/catalog/releases/tag/v5.0.0"
-  - description: "The GitHub URL of the commit tagged with v5.0.0."
+    value: "https://github.com/Imageomics/catalog/releases/tag/v5.0.1"
+  - description: "The GitHub URL of the commit tagged with v5.0.1."
     type: url
-    value: "https://github.com/Imageomics/catalog/tree/027f949f788acf4ffaffd32d5c4ac95629fa760c" # Update on release
+    value: "https://github.com/Imageomics/catalog/tree/<commit-hash>" # Update on release
 keywords:
   - imageomics
   - code
@@ -40,6 +40,6 @@ license: MIT
 message: "If you use this software, please cite it as below."
 repository-code: "https://github.com/Imageomics/catalog"
 title: "Imageomics Catalog"
-version: "5.0.0"
+version: "5.0.1"
 doi: "10.5281/zenodo.17602801"
 type: software

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "catalog",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "catalog",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^5.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catalog",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Repository for web-based Imageomics code, data, model, and demos catalog. This catalog is designed to use the GitHub API for searching all code repositories created under the [Imageomics GitHub Organization](https://github.com/Imageomics) and the Hugging Face API for searching all dataset, model, and spaces repositories created under the [Imageomics Hugging Face Organization](https://huggingface.co/imageomics).",
   "main": "main.js",
   "scripts": {

--- a/scripts/export-tags.js
+++ b/scripts/export-tags.js
@@ -17,7 +17,6 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { load } from 'js-yaml';
 import { validateConfig } from '../src/validateConfig.js';
-import { getPlatformDisplay } from '../src/utils/defineRibbonVals.js';
 import { filterNewAdditionalEntries } from '../src/utils/filterNewAdditionalEntries.js';
 import { getPlatformVals, getPlatformApiUrls } from '../src/utils/definePlatformVals.js';
 import { getPlatformHeaders } from './platformScriptHelpers.js';
@@ -36,7 +35,7 @@ if (errors.length) {
 }
 
 const CONFIG = rawConfig;
-const { ORGANIZATION_NAME, HF_ORGANIZATION_NAME, PLATFORM, API_BASE_URL, ADDITIONAL_REPOS } = CONFIG;
+const { ORGANIZATION_NAME, HF_ORGANIZATION_NAME, API_BASE_URL, ADDITIONAL_REPOS } = CONFIG;
 const ADDITIONAL_HF_REPOS = CONFIG.ADDITIONAL_HF_REPOS;
 
 // ---------------------------------------------------------------------------
@@ -62,8 +61,7 @@ const get = async (url) => {
 const allTags = new Set();
 
 const collectCodePlatformTags = async () => {
-    const platformDisplay = getPlatformDisplay(platform);
-    console.log(`Fetching ${platformDisplay.displayName || PLATFORM} repos...`);
+    console.log(`Fetching ${platform} repos...`);
     let allRepos = [];
     let nextUrl = `${ORG_API_URL}`;
 
@@ -92,7 +90,7 @@ const collectCodePlatformTags = async () => {
         (repo.topics || []).forEach(t => allTags.add(t.toLowerCase()));
     });
 
-    console.log(`  ${platformDisplay.displayName || PLATFORM}: processed ${orgNonForks.length} org repos + ${additionalRepos.length} additional repos`);
+    console.log(`  ${platform}: processed ${orgNonForks.length} org repos + ${additionalRepos.length} additional repos`);
 };
 
 const collectHFTags = async (repoType) => {


### PR DESCRIPTION
Resolves the SVG import issue by just using the "platform" key for logging when the export tags script is run.